### PR TITLE
ci: enable secret scanning using shared v1 workflow

### DIFF
--- a/.github/workflows/secret-scan-scheduled.yml
+++ b/.github/workflows/secret-scan-scheduled.yml
@@ -1,0 +1,17 @@
+name: Secret Scan (Scheduled)
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan-full:
+    uses: nscaledev/sre-shared-workflows/.github/workflows/secret-scan.yml@1
+    with:
+      scan-mode: full
+      fail-on-detection: "false"
+    secrets: inherit

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,22 @@
+name: Secret Scan (PR)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    uses: nscaledev/sre-shared-workflows/.github/workflows/secret-scan.yml@1
+    with:
+      scan-mode: pr
+      base-sha: ${{ github.event.pull_request.base.sha }}
+      head-sha: ${{ github.event.pull_request.head.sha }}
+      fail-on-detection: "true"
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add TruffleHog PR secret scan using shared workflow v1
- add scheduled full scan (non-blocking) for continuous monitoring
- keep GHAS as baseline; this adds CI-visible PR checks

## Validation
This rollout pattern was validated end-to-end in image-builder and k8s-deploy-infra:
- rollout PR merged (image-builder): https://github.com/nscaledev/image-builder/pull/49
- PR scan pass: https://github.com/nscaledev/image-builder/actions/runs/22096864896
- scheduled full scan pass: https://github.com/nscaledev/image-builder/actions/runs/22100233654
- Slack alert path validated (GitHub run): https://github.com/nscaledev/image-builder/actions/runs/22100530078
- Slack alert confirmed in channel: https://nscaleworkspace.slack.com/archives/C0AEPCR3WKD/p1771335270568499
- Rollout merged (k8s-deploy-infra): https://github.com/nscaledev/k8s-deploy-infra/pull/123

## Why this is safe
- same shared reusable workflow (nscaledev/sre-shared-workflows/.github/workflows/secret-scan.yml@1)
- same validated configuration pattern used in image-builder and k8s-deploy-infra

---
@codex review